### PR TITLE
fix(module): explicitly implements requiresMainQueueSetup on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Release 6.3.2
+===
+- Explicitly implements requiresMainQueueSetup on iOS
+
 Release 6.3.1
 ===
 - Fixes errors thrown on nullable values on older React Native versions

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -259,7 +259,7 @@ PODS:
     - React-cxxreact (= 0.63.4)
     - React-jsi (= 0.63.4)
   - React-jsinspector (0.63.4)
-  - react-native-incognia (6.3.1):
+  - react-native-incognia (6.3.2):
     - IncogniaBR (~> 6.2.0)
     - IncogniaCoreBR (~> 6.2.0)
     - IncogniaTrialBR (~> 6.2.0)
@@ -503,7 +503,7 @@ SPEC CHECKSUMS:
   React-jsi: a0418934cf48f25b485631deb27c64dc40fb4c31
   React-jsiexecutor: 93bd528844ad21dc07aab1c67cb10abae6df6949
   React-jsinspector: 58aef7155bc9a9683f5b60b35eccea8722a4f53a
-  react-native-incognia: 2d9718eaf64fb289b5dafa5c57a4fcb361330fe2
+  react-native-incognia: 5079bab5afe37ecff3a9129068c401bdb770cfc7
   React-RCTActionSheet: 89a0ca9f4a06c1f93c26067af074ccdce0f40336
   React-RCTAnimation: 1bde3ecc0c104c55df246eda516e0deb03c4e49b
   React-RCTBlob: a97d378b527740cc667e03ebfa183a75231ab0f0

--- a/ios/ICGIncogniaModule.m
+++ b/ios/ICGIncogniaModule.m
@@ -190,6 +190,10 @@ RCT_EXPORT_METHOD(trackPaymentSent:(NSDictionary *)parameters) {
     return constants;
 }
 
++ (BOOL)requiresMainQueueSetup {
+    return YES;
+}
+
 - (void)fillAddress:(ICGUserAddress *)userAddress addressDict:(NSDictionary *)addressDict {
     if (addressDict == nil) {
         return;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-incognia",
-  "version": "6.3.1",
+  "version": "6.3.2",
   "description": "Incognia React Native Library",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# TL;DR
<!-- What is the single most important thing in this PR -->
Release 6.3.2

# Description
<!--- Describe your changes in detail -->
Explicitly implements `requiresMainQueueSetup` on iOS do avoid warnings

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes warning

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If some boxes do not make sense for your PR, you may feel free to remove them -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

## Release
<!-- This should only be filled on release Pull Requests. -->
<!-- Feel free to delete this part from your PR, otherwise. -->

- [x] I have updated the version code.
- [x] I have updated the CHANGELOG.
- [x] I have updated the relevant environment variables.

# Comments
<!-- If you want to say anything else, do it here! :D -->