### PR TITLE
docs: Adding warning about command line tools while setting up

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,8 @@ To start the packager:
 yarn example start
 ```
 
+> Warning: if you encounter an error while running `yarn example start`, the issue may be related to your Android or iOS local setup rather than Metro itself. Make sure you have all development tools setup, as well as their command line tools.(e.g.: Xcode and Android Studio).
+
 To run the example app on Android:
 
 ```sh


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# TL;DR
<!-- What is the single most important thing in this PR -->

Adds a warning to CONTRIBUTING.md clarifying that failures when running yarn example start may come from incomplete Android/iOS local development setup, not Metro itself.

# Description
<!--- Describe your changes in detail -->
This PR updates the contributing guide to include a warning for developers running yarn example start.

The new note explains that errors during startup may be caused by missing or incomplete native development tooling, including platform-specific IDEs and command line tools such as Xcode and Android Studio, rather than Metro.

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change helps reduce confusion during local setup and troubleshooting.

When contributors hit an error while starting the example app, it is easy to assume Metro is the source of the problem. In practice, the issue may be related to missing Android or iOS dependencies in the local environment. Adding this warning makes the setup expectations clearer and should help contributors diagnose problems faster.

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If some boxes do not make sense for your PR, you may feel free to remove them -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

## Release
<!-- This should only be filled on release Pull Requests. -->
<!-- Feel free to delete this part from your PR, otherwise. -->

- [ ] I have updated the version code.
- [ ] I have updated the CHANGELOG.
- [ ] I have updated the relevant environment variables.

# Comments
<!-- If you want to say anything else, do it here! :D -->