### PR TITLE
fix(package.json): sets `tmp` version to fix vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "word-wrap": "1.2.5",
     "semver": "7.5.2",
     "shell-quote": "1.8.4",
-    "lodash": "4.18.1"
+    "lodash": "4.18.1",
+    "tmp": "0.2.7"
   },
   "peerDependencies": {
     "react": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8661,7 +8661,7 @@ os-name@4.0.1:
     macos-release "^2.5.0"
     windows-release "^4.0.0"
 
-os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
+os-tmpdir@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
@@ -10503,12 +10503,10 @@ time-stamp@^1.0.0:
   resolved "https://registry.yarnpkg.com/time-stamp/-/time-stamp-1.1.0.tgz#764a5a11af50561921b133f3b44e618687e0f5c3"
   integrity sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=
 
-tmp@^0.0.33:
-  version "0.0.33"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
-  integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
-  dependencies:
-    os-tmpdir "~1.0.2"
+tmp@0.2.7, tmp@^0.0.33:
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.7.tgz#26f4db11d1601ce8012dcb8a798ece1c06a99059"
+  integrity sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==
 
 tmpl@1.0.x:
   version "1.0.4"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# TL;DR
<!-- What is the single most important thing in this PR -->
Seta a versão do `tmp` pra `0.2.7` para resolver que o dependabot alertou. 

# Description
<!--- Describe your changes in detail -->
Botei a versão em `resolutions` por ser dependência transitiva, aí ele vai dar override na versão que o `react-native` e o `release-it` usam. Rodei o app no android e funcionou normalmente.

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Resolver [issue](https://github.com/inloco/react-native-incognia/security/dependabot/252) de security.