### PR TITLE
fix(package.json): sets `uuid` version to fix vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
     "shell-quote": "1.8.4",
     "lodash": "4.18.1",
     "tmp": "0.2.7",
-    "form-data": "4.0.6"
+    "form-data": "4.0.6",
+    "uuid": "11.1.1"
   },
   "peerDependencies": {
     "react": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10900,15 +10900,10 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-uuid@8.3.2, uuid@^8.3.0:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
-
-uuid@^3.3.2:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
-  integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+uuid@11.1.1, uuid@8.3.2, uuid@^3.3.2, uuid@^8.3.0:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
+  integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
 
 v8-compile-cache@^2.0.3:
   version "2.3.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# TL;DR
<!-- What is the single most important thing in this PR -->
Seta a versão do `uuid` pra `11.1.1` para resolver que o dependabot alertou. 

# Description
<!--- Describe your changes in detail -->
Botei a versão em `resolutions` por ser dependência transitiva, aí ele vai dar override na versão que os seguintes pacotes precisam:
- `@release-it/conventional-changelog`
- `react-native`
- `release-it`

Rodei o app no android e no iOS, funcionou normalmente.

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Resolver [issue](https://github.com/inloco/react-native-incognia/security/dependabot/249) de security.